### PR TITLE
fix : :bug: This object was destroyed

### DIFF
--- a/src/utils/cesiumPluginsExtends/libs/Draw.js
+++ b/src/utils/cesiumPluginsExtends/libs/Draw.js
@@ -839,7 +839,7 @@ Draw.prototype = {
   },
   // 移除所以handler 监听
   removeEventHandler() {
-    if(drawHandler){
+    if(drawHandler&&!drawHandler.isDestroyed()){
     drawHandler.removeInputAction(Cesium.ScreenSpaceEventType.MOUSE_MOVE)
     drawHandler.removeInputAction(Cesium.ScreenSpaceEventType.RIGHT_CLICK)
     drawHandler.removeInputAction(Cesium.ScreenSpaceEventType.LEFT_CLICK) //移除事件


### PR DESCRIPTION
Fixed  the  exception "DeveloperError: This object was destroyed, i.e., destroy() was called."

![1715780784983](https://github.com/dengxiaoning/cesium_dev_kit/assets/168287691/88b32551-9853-4ce0-b7d6-e679b76f675a)
